### PR TITLE
Move docker-compose `-d` flag after `up`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ git clone https://github.com/stefanwalther/speedy
 
 Then run from the root directory:
 ```sh
-$ docker-compose -d up
+$ docker-compose up -d
 ```
 
 This will essentially spin up three Docker containers:


### PR DESCRIPTION
The `-d` flag to run containers in the background needs to come after `up`.

Fixes #9 